### PR TITLE
Organize dependencies using version catalogs.

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:2.13.1"))
+    implementation(enforcedPlatform("com.fasterxml.jackson:jackson-bom:${libs.versions.jackson.get()}"))
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-toml")
     api("com.squareup:kotlinpoet:1.10.2")

--- a/runtime-interfaces/build.gradle.kts
+++ b/runtime-interfaces/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-    testImplementation("io.kotest:kotest-assertions-core:5.1.0")
-    testImplementation("io.mockk:mockk:1.12.2")
+    testImplementation(libs.bundles.tests)
 }
 
 tasks.named<Test>("test") {

--- a/runtime-source-json/build.gradle.kts
+++ b/runtime-source-json/build.gradle.kts
@@ -3,12 +3,9 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    implementation("com.fasterxml.jackson.jr:jackson-jr-objects:2.13.1")
     implementation(project(":runtime-interfaces"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-    testImplementation("io.kotest:kotest-assertions-core:5.1.0")
-    testImplementation("io.mockk:mockk:1.12.2")
+    implementation("com.fasterxml.jackson.jr:jackson-jr-objects:${libs.versions.jackson.get()}")
+    testImplementation(libs.bundles.tests)
 }
 
 tasks.named<Test>("test") {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -4,9 +4,7 @@ plugins {
 
 dependencies {
     api(project(":runtime-interfaces"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-    testImplementation("io.kotest:kotest-assertions-core:5.1.0")
-    testImplementation("io.mockk:mockk:1.12.2")
+    testImplementation(libs.bundles.tests)
 }
 
 tasks.named<Test>("test") {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,3 +7,18 @@ include("runtime-source-json")
 
 // Test projects
 include("generator-test-config", "tests")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            // Production dependencies
+            version("jackson", "2.13.1")
+
+            // Test dependencies
+            library("junit5", "org.junit.jupiter:junit-jupiter:5.8.2")
+            library("kotest-assertions", "io.kotest:kotest-assertions-core:5.1.0")
+            library("mockk", "io.mockk:mockk:1.12.2")
+            bundle("tests", listOf("junit5", "kotest-assertions", "mockk"))
+        }
+    }
+}

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -11,14 +11,11 @@ repositories {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    implementation(project(":generator-test-config"))
-    implementation(project(":runtime"))
-
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
-    testImplementation("io.kotest:kotest-assertions-core:5.1.0")
-    testImplementation("io.mockk:mockk:1.12.2")
     testImplementation(kotlin("reflect"))
+    testImplementation(project(":generator-test-config"))
+    testImplementation(project(":runtime"))
+
+    testImplementation(libs.bundles.tests)
 }
 
 tasks.named<Test>("test") {


### PR DESCRIPTION
This reduces the amount of copy-paste and also ensures we're using consistent versions of things, e.g. Jackson.

Closes #18.