### PR TITLE
Rewrite TypedConfig to use new WritableOnceDelegate for defaultSource.

### DIFF
--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/TypedConfig.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/TypedConfig.kt
@@ -4,17 +4,5 @@ import com.github.nanodeath.typedconfig.runtime.source.EnvSource
 import com.github.nanodeath.typedconfig.runtime.source.Source
 
 object TypedConfig {
-    private var sourceInitialized = false
-
-    var defaultSource: Source = EnvSource()
-        @Synchronized get
-        @Synchronized
-        set(value) {
-            if (!sourceInitialized) {
-                field = value
-                sourceInitialized = true
-            } else {
-                throw IllegalStateException("defaultSource has already been initialized!")
-            }
-        }
+    var defaultSource: Source by WriteOnceDelegate(EnvSource(), "defaultSource has already been initialized")
 }

--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/WriteOnceDelegate.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/WriteOnceDelegate.kt
@@ -1,0 +1,29 @@
+package com.github.nanodeath.typedconfig.runtime
+
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * A delegate that supports having an initial value and then being updated **once**. Updating more than that will
+ * throw an [IllegalStateException] with message [errorMessage].
+ *
+ * Thread-safe.
+ */
+internal class WriteOnceDelegate<T>(
+    initialValue: T,
+    private val errorMessage: String = "Property has already been written once"
+) : ReadWriteProperty<Any, T> {
+    @Volatile
+    private var value: T = initialValue
+
+    private var initialized = false
+
+    override fun getValue(thisRef: Any, property: KProperty<*>): T = value
+
+    @Synchronized
+    override fun setValue(thisRef: Any, property: KProperty<*>, value: T) {
+        check(!initialized) { errorMessage }
+        this.value = value
+        initialized = true
+    }
+}


### PR DESCRIPTION
Previously too much of the write-once logic was directly in TypedConfig.

Closes #26.