### PR TITLE
`description` can be specified for generated config to generate kdoc.

### DIFF
--- a/generator-test-config/src/main/resources/basic_test/config.tc.toml
+++ b/generator-test-config/src/main/resources/basic_test/config.tc.toml
@@ -1,5 +1,6 @@
 package = "com.github.nanodeath.typedconfig.test"
 class = "GeneratedConfig"
+description = "This is the basic configuration file."
 
 [maxLoginTries]
 type = "int"

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
@@ -24,6 +24,7 @@ class ConfigurationReader {
         val node = tomlMapper.readTree(file)
         val packageName = node.get("package").textValue()
         val className = ClassName(packageName, node.get("class").textValue())
+        val description = node.path("description").textValue()
         val configDefs: List<ConfigDef<*>> = parseConfigDefs(node, file)
 
         val configClass = TypeSpec.classBuilder(className)
@@ -47,6 +48,10 @@ class ConfigurationReader {
                 )
                 .build()
         )
+
+        if (!description.isNullOrBlank()) {
+            configClass.addKdoc(description)
+        }
 
         val innerClasses = mutableMapOf<InnerTypeSpec, TypeSpec.Builder>()
         for (configDef in configDefs) {

--- a/tests/src/test/kotlin/com/github/nanodeath/typedconfig/test/BasicTest.kt
+++ b/tests/src/test/kotlin/com/github/nanodeath/typedconfig/test/BasicTest.kt
@@ -8,7 +8,9 @@ import io.mockk.verifyAll
 import com.github.nanodeath.typedconfig.runtime.source.Source
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.should
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class BasicTest {
     @Test
@@ -46,5 +48,14 @@ class BasicTest {
         }
 
         verifyAll { source.getString("requiredConfig") }
+    }
+
+    @Test
+    fun descriptionIsAttachedToClass() {
+        val sourceText =
+            File("../generator-test-config/build/generated-sources-test/com/github/nanodeath/typedconfig/test/GeneratedConfig.kt")
+                .readText()
+
+        sourceText shouldContain "* This is the basic configuration file."
     }
 }


### PR DESCRIPTION
Closes #39.