### PR TITLE
Implement namespace key as a top-level key in config.

### DIFF
--- a/generator-test-config/src/main/resources/namespaced_keys/config.tc.toml
+++ b/generator-test-config/src/main/resources/namespaced_keys/config.tc.toml
@@ -1,0 +1,12 @@
+package = "com.github.nanodeath.typedconfig.test"
+class = "NamespacedConfig"
+namespace = "app"
+
+[port]
+type = "int"
+
+[databasePort]
+type = "int"
+
+[nested.key]
+type = "int"

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
@@ -27,7 +27,9 @@ class ConfigurationReader {
         val packageName = node.get("package").textValue()
         val className = ClassName(packageName, node.get("class").textValue())
         val description = node.path("description").textValue()
-        val configDefs: List<ConfigDef<*>> = parseConfigDefs(node, file)
+        val namespace = node.path("namespace").textValue().takeUnless { it.isNullOrBlank() }
+        val configDefs: List<ConfigDef<*>> =
+            parseConfigDefs(node, file, precedingKey = namespace?.let { listOf(it) } ?: emptyList())
 
         val configClass = TypeSpec.classBuilder(className)
         configClass.primaryConstructor(

--- a/tests/src/test/kotlin/com/github/nanodeath/typedconfig/test/NamespacedConfigTest.kt
+++ b/tests/src/test/kotlin/com/github/nanodeath/typedconfig/test/NamespacedConfigTest.kt
@@ -1,0 +1,40 @@
+package com.github.nanodeath.typedconfig.test
+
+import com.github.nanodeath.typedconfig.runtime.source.Source
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class NamespacedConfigTest {
+    @Test
+    fun namespacedKey() {
+        val source = mockk<Source>()
+        every { source.getInt(any()) } returns 8080
+
+        NamespacedConfig(source).app.port shouldBe 8080
+
+        verify { source.getInt("app.port") }
+    }
+
+    @Test
+    fun namespacedCompoundKey() {
+        val source = mockk<Source>()
+        every { source.getInt(any()) } returns 5432
+
+        NamespacedConfig(source).app.databasePort shouldBe 5432
+
+        verify { source.getInt("app.databasePort") }
+    }
+
+    @Test
+    fun namespacedNestedKey() {
+        val source = mockk<Source>()
+        every { source.getInt(any()) } returns 42
+
+        NamespacedConfig(source).app.nested.key shouldBe 42
+
+        verify { source.getInt("app.nested.key") }
+    }
+}


### PR DESCRIPTION
Automatically nests every key as if in the specified namespace. If you wanted a nested namespace, you can create two levels by saying `level1.level2` if you want.

I'm not positive this is an ideal implementation. Perhaps the keys alone should be nested and not the entire object structure?

Closes #32.