### PR TITLE
Implement duration key type.

### DIFF
--- a/generator-test-config/src/main/resources/basic_test/config.tc.toml
+++ b/generator-test-config/src/main/resources/basic_test/config.tc.toml
@@ -34,3 +34,14 @@ required = false
 [defaultString]
 type = "str"
 default = "localhost"
+
+[requiredDuration]
+type = "duration"
+
+[defaultDuration]
+type = "duration"
+default = "100 milliseconds"
+
+[optionalDuration]
+type = "duration"
+required = false

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/ConfigurationReader.kt
@@ -21,7 +21,8 @@ class ConfigurationReader {
             IntConfigDefGenerator,
             StringConfigDefGenerator,
             DoubleConfigDefGenerator,
-            BooleanConfigDefGenerator
+            BooleanConfigDefGenerator,
+            DurationConfigDefGenerator
         ).associateBy { it.key }
 
     fun readFile(file: File): FileSpec {

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/ConfigDef.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/ConfigDef.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 interface ConfigDef<T> {
     val key: String
-    val defaultValue: T?
+    val defaultValue: Any?
     val constraints: List<ClassName>
     val type: KClass<*>
     val keyClass: ClassName

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/DurationConfigDef.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/DurationConfigDef.kt
@@ -1,0 +1,18 @@
+package com.github.nanodeath.typedconfig.generate.configdef
+
+import com.github.nanodeath.typedconfig.generate.RUNTIME_PACKAGE
+import com.squareup.kotlinpoet.ClassName
+import java.time.Duration
+
+internal data class DurationConfigDef(
+    override val key: String,
+    override val defaultValue: String?,
+    override val constraints: List<ClassName>,
+    override val metadata: ConfigDefMetadata
+) : ConfigDef<Duration> {
+    override val type = Duration::class
+    override val keyClass =
+        ClassName("$RUNTIME_PACKAGE.key", if (metadata.required) "DurationKey" else "NullableDurationKey")
+
+    override val literalPlaceholder = "%S"
+}

--- a/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/DurationConfigDefGenerator.kt
+++ b/generator/src/main/kotlin/com/github/nanodeath/typedconfig/generate/configdef/DurationConfigDefGenerator.kt
@@ -1,0 +1,13 @@
+package com.github.nanodeath.typedconfig.generate.configdef
+
+import com.squareup.kotlinpoet.ClassName
+
+internal object DurationConfigDefGenerator : ConfigDefGenerator<DurationConfigDef> {
+    override val key = "duration"
+
+    override fun generate(
+        key: String, defaultValue: String?, constraints: List<ClassName>, metadata: ConfigDefMetadata
+    ) = DurationConfigDef(
+        key, defaultValue, constraints, metadata
+    )
+}

--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/Exceptions.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/Exceptions.kt
@@ -1,10 +1,12 @@
 package com.github.nanodeath.typedconfig.runtime
 
+@Suppress("unused")
 sealed class TypedConfigException : RuntimeException {
     constructor() : super()
     constructor(message: String) : super(message)
-
 }
 
 class MissingConfigurationException(key: String) :
     TypedConfigException("Config `$key` is required but could not be resolved and no default was provided")
+
+class ParseException(key: String, msg: String) : TypedConfigException("Failed to parse `$key`: $msg")

--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/key/DurationKey.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/key/DurationKey.kt
@@ -1,0 +1,46 @@
+package com.github.nanodeath.typedconfig.runtime.key
+
+import com.github.nanodeath.typedconfig.runtime.MissingConfigurationException
+import com.github.nanodeath.typedconfig.runtime.ParseException
+import com.github.nanodeath.typedconfig.runtime.source.Source
+import java.time.Duration
+import java.time.format.DateTimeParseException
+
+class DurationKey(
+    private val name: String,
+    private val source: Source,
+    private val default: String?,
+    @Suppress("unused") private val constraints: List<Unit>
+) : Key<Duration> {
+    private val parsedDefault: Duration? by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        default?.let { parseDuration(it, name) }
+    }
+
+    override fun resolve(): Duration =
+        source.getString(name)?.let { parseDuration(it, name) }
+            ?: parsedDefault
+            ?: throw MissingConfigurationException(name)
+
+    internal companion object {
+        private val longRegex = Regex("(?<count>\\d+) (?<unit>milliseconds?|minutes?|hours?|days?)")
+        private val shortRegex = Regex("(?<count>\\d+)(?<unit>ms|m|h|d)")
+
+        fun parseDuration(str: String, key: String): Duration = try {
+            Duration.parse(str)
+        } catch (e: DateTimeParseException) {
+            val (count, unit) = (longRegex.matchEntire(str)?.let { match ->
+                match.groups["count"]!!.value.toLong() to match.groups["unit"]!!.value
+            } ?: shortRegex.matchEntire(str)?.let { match ->
+                match.groups["count"]!!.value.toLong() to match.groups["unit"]!!.value
+            }) ?: throw ParseException(key, "invalid duration: '$str'")
+            when (unit) {
+                "ms", "millisecond", "milliseconds" -> Duration.ofMillis(count)
+                "m", "minute", "minutes" -> Duration.ofMinutes(count)
+                "h", "hour", "hours" -> Duration.ofHours(count)
+                "d", "day", "days" -> Duration.ofDays(count)
+                // This matcher is actually exhaustive, so this line shouldn't even be reachable.
+                else -> throw UnsupportedOperationException("Unexpected unit $unit, probably a TypedConfig bug")
+            }
+        }
+    }
+}

--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/key/NullableDurationKey.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/key/NullableDurationKey.kt
@@ -1,0 +1,13 @@
+package com.github.nanodeath.typedconfig.runtime.key
+
+import com.github.nanodeath.typedconfig.runtime.source.Source
+import java.time.Duration
+
+class NullableDurationKey(
+    private val name: String,
+    private val source: Source,
+    @Suppress("unused") private val default: Unit?,
+    @Suppress("unused") private val constraints: List<Unit>
+) : Key<Duration?> {
+    override fun resolve(): Duration? = source.getString(name)?.let { DurationKey.parseDuration(it, name) }
+}

--- a/runtime/src/test/kotlin/com/github/nanodeath/typedconfig/runtime/key/DurationKeyTest.kt
+++ b/runtime/src/test/kotlin/com/github/nanodeath/typedconfig/runtime/key/DurationKeyTest.kt
@@ -1,0 +1,44 @@
+package com.github.nanodeath.typedconfig.runtime.key
+
+import com.github.nanodeath.typedconfig.runtime.ParseException
+import io.kotest.assertions.forEachAsClue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class DurationKeyTest {
+    @Test
+    fun parseDuration() {
+        val day = Duration.ofDays(1L)
+        val dayInVariousFormats = listOf(
+            "${day.toMillis()} milliseconds",
+            "${day.toMillis()} millisecond",
+            "${day.toMillis()}ms",
+            "${day.toMinutes()} minutes",
+            "${day.toMinutes()} minute",
+            "${day.toMinutes()}m",
+            "${day.toHours()} hours",
+            "${day.toHours()} hour",
+            "${day.toHours()}h",
+            "${day.toDays()} days",
+            "${day.toDays()} day",
+            "${day.toDays()}d"
+        )
+
+        dayInVariousFormats.forEachAsClue { durationString ->
+            DurationKey.parseDuration(durationString, "key") shouldBe day
+        }
+    }
+
+    @Test
+    fun invalidDuration() {
+        shouldThrow<ParseException> {
+            DurationKey.parseDuration("hello", "key")
+        } should {
+            it.shouldHaveMessage("Failed to parse `key`: invalid duration: 'hello'")
+        }
+    }
+}


### PR DESCRIPTION
Closes #52.

This was implemented a little differently than the other types, as it the default value doesn't parse down immediately into a Duration. This is primarily because the String->Duration parsing logic is non-trivial and I'd hate to duplicate it in the generator (for translating default values) and in the runtime (for translating runtime-provided values). So instead if just passes a string down through the generated code, which is then parsed the first time the config is accessed.

Pros:

* Reuse the parsing logic in the runtime
* KDoc is more natural -- prints out the configured default value verbatim

Cons:

* Invalid default configuration values won't get detected until runtime
* We pay a bit of startup time to parse the default value at runtime
  * However, this cost is likely small to begin with, and we mitigate it by putting it in a `lazy`.

In general, this isn't a bad strategy -- it's a good way to guarantee default values and runtime values get parsed the same way. However, those cons would apply to every type, too. The only real alternative would be to create another module that's shared by the generator and runtime, but I'm not quite mentally prepared for that yet.