### PR TITLE
build: Gradle plugin should use a properties file to ensure the runtime/generator versions match the plugin

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,6 +10,14 @@ repositories {
     mavenCentral()
 }
 
+dependencies {
+    testImplementation(libs.bundles.tests)
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}
+
 gradlePlugin {
     plugins {
         create("TypedConfigPlugin") {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 plugins {
     kotlin("jvm") version "1.6.10"
     `maven-publish`

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 plugins {
     kotlin("jvm") version "1.6.10"
     `maven-publish`
@@ -28,4 +30,41 @@ publishing {
             from(components["java"])
         }
     }
+}
+
+val generateSourcesTask = tasks.register<Sync>("generateSources") {
+    val tokens = mapOf(
+        "VERSION" to rootProject.version
+    )
+    inputs.properties(tokens)
+    from("src/main/kotlin")
+    into(buildDir.resolve("generated-src"))
+    filter<ReplaceTokens>(mapOf("tokens" to tokens))
+}
+
+lateinit var releaseSourceSet: SourceSet
+sourceSets {
+    releaseSourceSet = create("release") {
+        java {
+            compiledBy(generateSourcesTask) { t ->
+                objects.directoryProperty().also { it.set(t.destinationDir) }
+            }
+            srcDir(generateSourcesTask.map { it.destinationDir })
+            compileClasspath = sourceSets.main.get().compileClasspath
+            runtimeClasspath = sourceSets.main.get().runtimeClasspath
+        }
+    }
+}
+
+tasks.register<Jar>("releaseJar") {
+    group = "build"
+    archiveBaseName.set("${project.name}-release")
+    from(releaseSourceSet.output)
+}
+
+tasks.register<Jar>("releaseSourcesJar") {
+    group = "build"
+    archiveClassifier.set("sources")
+    archiveBaseName.set("${project.name}-release")
+    from(releaseSourceSet.java.sourceDirectories)
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -30,6 +30,7 @@ val generateResourcesTask = tasks.register("generateResources") {
     )
     inputs.properties(properties)
     outputs.dir(generatedResourcesDirectory)
+    outputs.files(fileTree(generatedResourcesDirectory))
     doLast {
         val path = generatedResourcesDirectory.resolve("com/github/nanodeath/typedconfig/plugin.properties")
         path.parentFile.mkdirs()

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/PluginProperties.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/PluginProperties.kt
@@ -2,7 +2,7 @@ package com.github.nanodeath.typedconfig
 
 import java.util.Properties
 
-class PluginProperties(map: Map<Any, Any>) {
+internal class PluginProperties(map: Map<Any, Any>) {
     val version: String by map
 
     companion object {

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/PluginProperties.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/PluginProperties.kt
@@ -1,0 +1,16 @@
+package com.github.nanodeath.typedconfig
+
+import java.util.Properties
+
+class PluginProperties(map: Map<Any, Any>) {
+    val version: String by map
+
+    companion object {
+        fun fromPropertiesFile(): PluginProperties {
+            val props = Properties()
+            val propertiesFile = checkNotNull(PluginProperties::class.java.getResourceAsStream("plugin.properties"))
+            propertiesFile.use { props.load(it) }
+            return PluginProperties(props)
+        }
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/TypedConfigPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/TypedConfigPlugin.kt
@@ -26,13 +26,16 @@ const val DEFAULT_CONFIG_FILENAME = "config.tc.toml"
 
 class TypedConfigPlugin : Plugin<Project> {
     override fun apply(project: Project) {
+        val pluginProperties = PluginProperties.fromPropertiesFile()
+        val versions = Versions(pluginProperties)
+
         val extension = project.extensions.create("typedConfig", TypedConfigExtension::class.java)
 
         val configuration = project.configurations.create("typedConfigCodegen")
-        project.dependencies.add(configuration.name, Versions.codegenDependency)
+        project.dependencies.add(configuration.name, versions.codegenDependency)
         project.plugins.withType(JavaPlugin::class.java) {
             project.dependencies.add(
-                JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Versions.runtimeDependency
+                JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, versions.runtimeDependency
             )
         }
         val generatedSourcesDir = project.buildDir.resolve("generated-config")

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/TypedConfigPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/TypedConfigPlugin.kt
@@ -29,10 +29,10 @@ class TypedConfigPlugin : Plugin<Project> {
         val extension = project.extensions.create("typedConfig", TypedConfigExtension::class.java)
 
         val configuration = project.configurations.create("typedConfigCodegen")
-        project.dependencies.add(configuration.name, "com.github.nanodeath.typedconfig:codegen:1.0-SNAPSHOT")
+        project.dependencies.add(configuration.name, Versions.codegenDependency)
         project.plugins.withType(JavaPlugin::class.java) {
             project.dependencies.add(
-                JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, "com.github.nanodeath.typedconfig:runtime:1.0-SNAPSHOT"
+                JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Versions.runtimeDependency
             )
         }
         val generatedSourcesDir = project.buildDir.resolve("generated-config")

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/Versions.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/Versions.kt
@@ -1,0 +1,7 @@
+package com.github.nanodeath.typedconfig
+
+internal object Versions {
+    private const val typedConfigVersion = "@VERSION@"
+    val codegenDependency = "com.github.nanodeath.typedconfig:codegen:$typedConfigVersion"
+    val runtimeDependency = "com.github.nanodeath.typedconfig:runtime:$typedConfigVersion"
+}

--- a/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/Versions.kt
+++ b/gradle-plugin/src/main/kotlin/com/github/nanodeath/typedconfig/Versions.kt
@@ -1,7 +1,6 @@
 package com.github.nanodeath.typedconfig
 
-internal object Versions {
-    private const val typedConfigVersion = "@VERSION@"
-    val codegenDependency = "com.github.nanodeath.typedconfig:codegen:$typedConfigVersion"
-    val runtimeDependency = "com.github.nanodeath.typedconfig:runtime:$typedConfigVersion"
+internal class Versions(pluginProperties: PluginProperties) {
+    val codegenDependency = "com.github.nanodeath.typedconfig:codegen:${pluginProperties.version}"
+    val runtimeDependency = "com.github.nanodeath.typedconfig:runtime:${pluginProperties.version}"
 }

--- a/gradle-plugin/src/test/kotlin/com/github/nanodeath/typedconfig/VersionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/github/nanodeath/typedconfig/VersionsTest.kt
@@ -1,0 +1,27 @@
+package com.github.nanodeath.typedconfig
+
+import io.kotest.matchers.should
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldEndWith
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class VersionsTest {
+    @Test
+    fun codegenTest() {
+        val versions = Versions(PluginProperties(mapOf("version" to "FOO")))
+        versions.codegenDependency should {
+            it shouldContain ":codegen:"
+            it shouldEndWith "FOO"
+        }
+    }
+
+    @Test
+    fun runtimeTest() {
+        val versions = Versions(PluginProperties(mapOf("version" to "FOO")))
+        versions.runtimeDependency should {
+            it shouldContain ":runtime:"
+            it shouldEndWith "FOO"
+        }
+    }
+}


### PR DESCRIPTION
Originally I was going to use some pre-compile string replacement to go from @VERSION@ in the source code to the current build version, but getting this to work nicely in Gradle is shockingly hard.

So instead I just generate a special properties file resource and load that at runtime instead. Not ideal, but also took me like 15 minutes, vs. 4 hours (without success) for the other approach.

Closes #80.