### PR TITLE
fix: correct CachedSource.kt to perform correct calls on wrapped source.

### DIFF
--- a/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/source/CachedSource.kt
+++ b/runtime/src/main/kotlin/com/github/nanodeath/typedconfig/runtime/source/CachedSource.kt
@@ -18,7 +18,7 @@ class CachedSource(private val delegate: Source) : Source {
 
     override fun getString(key: String): String? {
         if (!cache.containsKey(key)) {
-            val value = delegate.getInt(key)
+            val value = delegate.getString(key)
             logger.trace("Caching {} -> {}", key, value)
             cache.putIfAbsent(key, value)
         }
@@ -27,7 +27,7 @@ class CachedSource(private val delegate: Source) : Source {
 
     override fun getDouble(key: String): Double? {
         if (!cache.containsKey(key)) {
-            val value = delegate.getInt(key)
+            val value = delegate.getDouble(key)
             logger.trace("Caching {} -> {}", key, value)
             cache.putIfAbsent(key, value)
         }

--- a/runtime/src/test/kotlin/com/github/nanodeath/typedconfig/runtime/source/CachedSourceTest.kt
+++ b/runtime/src/test/kotlin/com/github/nanodeath/typedconfig/runtime/source/CachedSourceTest.kt
@@ -1,0 +1,67 @@
+package com.github.nanodeath.typedconfig.runtime.source
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+class CachedSourceTest {
+    @MockK
+    lateinit var innerSource: Source
+
+    private val subject by lazy { innerSource.cached() }
+
+    @Test
+    fun cachesInts() {
+        every { innerSource.getInt(any()) } returns 1
+
+        subject.getInt("foo") shouldBe 1
+        subject.getInt("foo") shouldBe 1
+
+        verify(atMost = 1) { innerSource.getInt("foo") }
+    }
+
+    @Test
+    fun cachesStrings() {
+        every { innerSource.getString(any()) } returns "bar"
+
+        subject.getString("foo") shouldBe "bar"
+        subject.getString("foo") shouldBe "bar"
+
+        verify(atMost = 1) { innerSource.getString("foo") }
+    }
+
+    @Test
+    fun cachesDoubles() {
+        every { innerSource.getDouble(any()) } returns 3.14
+
+        subject.getDouble("foo") shouldBe 3.14
+        subject.getDouble("foo") shouldBe 3.14
+
+        verify(atMost = 1) { innerSource.getDouble("foo") }
+    }
+
+    @Test
+    fun cachesBooleans() {
+        every { innerSource.getBoolean(any()) } returns true
+
+        subject.getBoolean("foo") shouldBe true
+        subject.getBoolean("foo") shouldBe true
+
+        verify(atMost = 1) { innerSource.getBoolean("foo") }
+    }
+
+    @Test
+    fun cachesLists() {
+        every { innerSource.getList(any()) } returns listOf("1", "2")
+
+        subject.getList("foo") shouldBe listOf("1", "2")
+        subject.getList("foo") shouldBe listOf("1", "2")
+
+        verify(atMost = 1) { innerSource.getList("foo") }
+    }
+}


### PR DESCRIPTION
Previously it was calling `getInt` for `getDouble` and `getString`. Oops.

Closes #102.